### PR TITLE
Fix default bitmask for IPv6 when initializing the class from third party code

### DIFF
--- a/clientsubnetoption.py
+++ b/clientsubnetoption.py
@@ -65,7 +65,7 @@ class ClientSubnetOption(dns.edns.Option):
             the authoritative server.
     """
 
-    def __init__(self, ip, bits=24, scope=0, option=ASSIGNED_OPTION_CODE):
+    def __init__(self, ip, bits=-1, scope=0, option=ASSIGNED_OPTION_CODE):
         super(ClientSubnetOption, self).__init__(option)
 
         n = None
@@ -76,10 +76,14 @@ class ClientSubnetOption(dns.edns.Option):
                 n = socket.inet_pton(family, ip)
                 if family == socket.AF_INET6:
                     f = FAMILY_IPV6
+                    if bits == -1:
+                        bits = 48
                     hi, lo = struct.unpack('!QQ', n)
                     ip = hi << 64 | lo
                 elif family == socket.AF_INET:
                     f = FAMILY_IPV4
+                    if bits == -1:
+                        bits = 24
                     ip = struct.unpack('!L', n)[0]
             except Exception:
                 pass


### PR DESCRIPTION
Currently, the default bits are set to /24 for IPv6 when initializing the class without supplying any bit mask:

https://github.com/opendns/dnspython-clientsubnetoption/blob/77ca2859ec97cf52a099221abd8d5426889a829a/clientsubnetoption.py#L68

This means that this example with an IP of one of the @OpenDNS Resolvers:

```python
cso = ClientSubnetOption("2620:119:35::35")
```
ends up on requesting DNS results targeted for `2620:100::/24`.

Some authoritative DNS servers will then be responding with results they claim to be targeted for e.g. `2620\:100::/44`, which is completely outside of the network area of the initial request.

Since IPv6 allocations typically vary in the area of /29 - /32 with most registries, the IPv6 defaults for the class will produce very inaccurate results if used in production, as the request will be covering between 32 to 256 different "networks".

And with End User space, that are typically starting from /48, the situation will just be worse than that. 

This PR aims to provide consistency between the class and the CLI version of the dnspython-clientsubnetoption code, by setting the class's default bits to "-1" and automatically adjusting the bits when calculating the IP(v4|v6) address inside the class if the mask is not set, with the defaults being 24 for IPv4, and 48 for IPv6, exactly as the CLI version does:

https://github.com/opendns/dnspython-clientsubnetoption/blob/77ca2859ec97cf52a099221abd8d5426889a829a/clientsubnetoption.py#L291-L295

I also suggest publishing a new release with the changes.